### PR TITLE
Close multiple tabs at once

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,12 +27,16 @@ function closeTabs(sender, tabs) {
 }
 
 function closeOtherTabs(sender, tabs) {
+    var ids = [];
     for (var tab of tabs) {
         if (tab.id == sender.id) {
             continue;
         } else if (!tab.pinned) {
-            browser.tabs.remove(tab.id);
+            ids.push(tab.id);
         }
+    }
+    if (ids.length > 0) {
+        browser.tabs.remove(ids);
     }
 }
 


### PR DESCRIPTION
Close multiple tabs with a single `browser.tabs.close` call.
[Starting from Firefox 85](https://bugzilla.mozilla.org/show_bug.cgi?id=1650956), this allows the user to restore closing the tabs with the "undo close tabs" menu option or `ctrl + shift + t`.

Adapted from #11